### PR TITLE
Feat: Improve send command

### DIFF
--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -129,9 +129,14 @@ class CommandLine(cmd.Cmd):
         print("The json message history file has been cleared.\n")
 
 
-    def do_help(self, _):
-        """Displays the help string."""
-        print(help_strings.HELP_MESSAGE)
+    def do_help(self, arg):
+        """Displays help messages."""
+        if arg == "send":
+            cmd_method = getattr(self, "do_send")
+            print(f"Description: {cmd_method.__doc__}")
+            print(f"Usage: send <command> [data1 ...] [option=value ...]")
+        else:
+            print(help_strings.HELP_MESSAGE)
 
 
     def do_list(self, _):

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -25,7 +25,7 @@ class CommandLine(cmd.Cmd):
     # initialize the object
     def __init__(self, out_queue):
         super().__init__()
-        self.intro = "\nAvailable commands:\nsend\nsetid\nquery\nclear\nhelp\nlist\nexit\n"
+        self.intro = "\nAvailable commands:\nsend\niamnow\nquery\nclear\nhelp\nlist\nexit\n"
         self.prompt = ">> "
         self.out_msg_queue = out_queue
         self.sender_id = NodeID.CDH
@@ -96,8 +96,8 @@ class CommandLine(cmd.Cmd):
             return
 
 
-    def do_setid(self, arg):
-        """Changes the sender ID."""
+    def do_iamnow(self, arg):
+        """Changes the default sender ID."""
         try:
             node_id = NodeID(int(arg, 0))
             if node_id in NodeID:
@@ -185,15 +185,16 @@ def parse_send(args: str) -> tuple[str, str, dict, str]:
 
     for index, part in enumerate(parts[1:]):
         try:
-            if '=' in part:  # check if key-value pair.
+            # check if key-value pair
+            if '=' in part:  
                 key, value = part.split('=')
                 options[key] = value
-            else: # treat as data argument
+            # else treat as data argument
+            else:
                 value = format(int(part, 16), 'x')
                 # restore leading zeroes
                 data += value.zfill(len(part) - (2 if '0x' in part else 0))
         except ValueError:
-            # invalid argument
             error = f"Unknown argument '{part}'"
     
     return cmd_id, data, options, error

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -175,6 +175,7 @@ def init_json():
             history.write("[]")
 
 def parse_send(args: str) -> tuple[str, str, dict, str]:
+    """Parses arguments for `do_send`."""
     parts = args.split()
 
     cmd_id = parts[0]

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -47,9 +47,13 @@ class CommandLine(cmd.Cmd):
             data = args[1]
             options = args[2]
 
+            if "priority" in options:
+                priority = int(options["priority"])
+                if not 0 <= priority <= 32:
+                    raise ArgumentException("Invalid priority")
+            else:
+                priority = COMM_INFO[cmd_id]["priority"]
 
-        # now we can use the code to find its priority
-        priority = COMM_INFO[cmd_id]["priority"]
             if "from" in options:
                 sender_id = NodeID[options["from"]]
             else:

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -49,12 +49,14 @@ class CommandLine(cmd.Cmd):
             for key in options:
                 if key == "priority":
                     priority = int(options["priority"])
-                    
-                if key == "from":
-                    sender_id = NodeID[options["from"]]
-
-                if key == "to":
-                    dest_id = NodeID[options["to"]]
+                
+                try:
+                    if key == "from":
+                        sender_id = NodeID[options["from"]]
+                    if key == "to":
+                        dest_id = NodeID[options["to"]]
+                except KeyError:
+                    raise ArgumentException("Invalid node ID")
             
             # raise exceptions for invalid arguments
             if parse_error:

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -175,9 +175,10 @@ def parse_send(args: str) -> tuple[int, str, dict, str]:
             if '=' in part:  # check if key-value pair.
                 key, value = part.split('=')
                 options[key] = value
-            else:
-                # treat as data argument
-                data += format(int(part, 16), 'x')
+            else: # treat as data argument
+                value = format(int(part, 16), 'x')
+                # restore leading zeroes
+                data += value.zfill(len(part) - (2 if '0x' in part else 0))
         except ValueError:
             # invalid argument
             error = f"Unknown argument '{part}'"

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -57,6 +57,10 @@ class CommandLine(cmd.Cmd):
         else:
             dest_id = COMM_INFO[cmd_id]["dest"]
 
+            if dest_id is None: # common command, abort the send
+                print(f"{cmd_id.name} requires a recipient")
+                return
+
         buffer = bytearray([priority, sender_id.value, dest_id.value, cmd_id.value, 0, 0, 0, 0, 0, 0, 0])
 
         if data:

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -63,12 +63,12 @@ class CommandLine(cmd.Cmd):
                 if dest_id is None: # common command
                     raise ArgumentException(f"{cmd_id.name} requires a recipient")
 
-            buffer = bytearray([priority, sender_id.value, dest_id.value, cmd_id.value, 0, 0, 0, 0, 0, 0, 0])
+            # create buffer with empty payload
+            buffer = bytearray([priority, sender_id.value, dest_id.value, cmd_id.value] + [0] * 7)
 
             if data:
                 # pad data with zeros to create a full message
-                while len(data) < 14:
-                    data += "0"
+                data = data.ljust(14, "0")
 
                 # fill the buffer with the data bytes
                 position = 0

--- a/soti/serial_reader.py
+++ b/soti/serial_reader.py
@@ -23,7 +23,7 @@ def serial_reader(in_msg_queue, out_msg_queue, soti_port):
             try:
                 # write the appropriate command + arguments to the serial device
                 out_msg = out_msg_queue.get(block=False)
-                print(f"Sending bytes to the satellite: 0x{out_msg.hex()}")
+                print(f"Sending bytes to the satellite: 0x{out_msg.hex().upper()}")
                 ser.write(out_msg)
             except Empty:
                 pass

--- a/soti/utils/help_strings.py
+++ b/soti/utils/help_strings.py
@@ -4,8 +4,8 @@ from utils.constants import CmdID
 
 
 HELP_MESSAGE = """
-send: sends a command to the satellite (input is hexadecimal, ex. 0xA1)
-setid: sets the sender ID of sent commands
+send: sends a command to the satellite
+iamnow: sets the default sender ID of sent commands
 query: queries the satellite's message history for information
 clear: clears the json message history file
 help: displays this message


### PR DESCRIPTION
**Features:**
All parameters when sending a command to the satellite can now be overridden. The new syntax is this:
`>> send <command> [data ...] [options ...]`

`command` is either the name of the command or its corresponding value in hex (which can be found using the `list` command).
`data` is any hex number and can be provided multiple times.
`options` is the main addition, you can set the parameters `from`, `to`, and `priority`.

For example:
`>> send PLD_SET_ACTIVE_ENVS 123abc from=ADCS 0x00EF priority=31`
Correctly sends the message: `0x1F020321123ABC00EF0000`

**Notes:**
I tried to take a very forgiving approach to invalid input. Rather than the CLI crashing, an appropriate error message is printed and the send command is aborted, returning you to an input state. This involves a fair amount of exception-handling code, which Python is good at, but can quickly get messy so I tried to keep it as neatly structured as possible. 

**TODO:**
- [ ] There's some inconsistencies in input: 
- 1. the `iamnow` command only accepts a number for the new sender ID, where as using `from=` in the send command only accepts the `NodeID` name.
- 2. the input for `priority=` is a decimal value, but this is converted into hex when the message is sent.