### PR TITLE
Feat: Add Virtual Mode

### DIFF
--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -214,8 +214,6 @@ _'._ /___/\\____/ /_/ /___/   *_.__       /_/
 
 
 if __name__ == "__main__":
-    multiprocessing.set_start_method('spawn')
-
     print(SPLASH)
     print("\nWelcome to the SOTI CLI!\n")
 
@@ -227,15 +225,13 @@ if __name__ == "__main__":
 
     selected_port = input("\nEnter the port to receive messages from:")
 
+    init_json()
+
     in_msg_queue = multiprocessing.Queue() # messages received from SOTI board
     out_msg_queue = multiprocessing.Queue() # messages to send to SOTI board
 
-    init_json()
-
-    serial_reader_proc = multiprocessing.Process(target=serial_reader, args=(in_msg_queue, out_msg_queue, selected_port))
-    serial_reader_proc.start()
-
-    parser_proc = multiprocessing.Process(target=parser, args=(in_msg_queue,))
-    parser_proc.start()
+    multiprocessing.set_start_method('spawn')
+    multiprocessing.Process(target=serial_reader, args=(in_msg_queue, out_msg_queue, selected_port)).start()
+    multiprocessing.Process(target=parser, args=(in_msg_queue,)).start()
 
     CommandLine(out_msg_queue).cmdloop()

--- a/soti/message_parser.py
+++ b/soti/message_parser.py
@@ -8,7 +8,6 @@ from utils.constants import NodeID, CmdID, MSG_HISTORY_PATH
 
 def parser(in_msg_queue):
     """Gets messages from the incoming queue and parses them"""
-    print("Parser Status: Running")
     while True:
         new_msg_raw = in_msg_queue.get()
         new_msg_json = parse_message(new_msg_raw)

--- a/soti/serial_reader.py
+++ b/soti/serial_reader.py
@@ -7,7 +7,6 @@ from utils.constants import MSG_SIZE
 
 def serial_reader(in_msg_queue, out_msg_queue, soti_port):
     """Handles incoming and outgoing serial messages."""
-    print("\nSerial Handler Status: Running")
     # use a write timeout of 1 second to avoid infinite blocking
     with serial.Serial(soti_port, baudrate=115200, write_timeout=1) as ser:
         while True:


### PR DESCRIPTION
Virtual mode allows you to develop features for the SOTI CLI without needing to actually connect to real hardware. This will save us hours of development time.

It currently just disables the child processes for reading serial input and parsing incoming messages. Theoretically, we could update `serial_reader.py` to actually consume commands as though it was transmitting it through the wire. But I haven't implemented that. Feel free to implement it yourself if that interests you.