### PR TITLE
Feat: Log sessions

### DIFF
--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -188,17 +188,25 @@ def init_json(port: str) -> str:
     return file_name
 
 def finalize_json(file_name):
+    """Writes the session length to the log file."""
     with open(SAVE_DATA_DIR / file_name, 'r', encoding="utf_8") as history:
         log = json.load(history)
 
+    # get the datetime corresponding to the file name
     session_start = datetime.datetime.strptime(file_name.strip(".txt"), SESSION_FILE_FORMAT)
+
     total_seconds = int((datetime.datetime.now() - session_start).total_seconds())
     minutes, seconds = divmod(total_seconds, 60)
+    hours, minutes = divmod(minutes, 60)
 
-    log["session-length"] = f"{minutes:02d}:{seconds:02d}"
+    # conditionally add hours and format to two digits
+    session_length = ""
+    if hours:
+        session_length = f"{hours:02d}"
+    log["session-length"] = session_length + f"{minutes:02d}:{seconds:02d}"
 
     with open(SAVE_DATA_DIR / file_name, 'w', encoding="utf_8") as history:
-        json.dump(log, history, indent=4)  # Write back the updated JSON with indentation
+        json.dump(log, history, indent=4)
 
 def parse_send(args: str) -> tuple[str, str, dict, str]:
     """Parses arguments for `do_send`."""

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -159,7 +159,7 @@ class CommandLine(cmd.Cmd):
 # FUNCTIONS
 # ----------------------------------------------------------
 
-def init_json(port: str) -> str:
+def init_session_log(port: str) -> str:
     """Initializes the file which logs the session."""
     if not os.path.exists(SESSIONS_DIR):
         os.mkdir(SESSIONS_DIR)
@@ -184,7 +184,7 @@ def init_json(port: str) -> str:
 
     return file_name
 
-def finalize_json(file_name):
+def finalize_session_log(file_name):
     """Writes the session length to the log file."""
     with open(SESSIONS_DIR / file_name, encoding="utf_8") as history:
         log = history.read()
@@ -271,7 +271,7 @@ if __name__ == "__main__":
                 pass
             print("Invalid input. Please enter the number corresponding to your selection.")
 
-        output_file_name = init_json(selected_port.device)
+        output_file_name = init_session_log(selected_port.device)
 
         multiprocessing.set_start_method('spawn')
         write_msg_queue = multiprocessing.Queue() # messages to be written to file
@@ -284,7 +284,7 @@ if __name__ == "__main__":
 
         CommandLine(out_msg_queue, write_msg_queue, output_file_name).cmdloop()
 
-        finalize_json(output_file_name)
+        finalize_session_log(output_file_name)
 
     except KeyboardInterrupt:
         pass

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -169,9 +169,12 @@ def init_session_log(port: str) -> str:
     file_format = session_start.strftime(SESSION_FILE_FORMAT)
     file_name = f"{file_format}.log"
 
+    date = session_start.strftime("%Y-%m-%d")
+    time = session_start.strftime("%H:%M:%S")
+
     header_dict = {
-        "date": file_format.split("_")[0],
-        "time": file_format.split("_")[1],
+        "date": date,
+        "time": time,
         "session-length": None,
         "port": port,
         "messages": ""

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -4,22 +4,20 @@ The main soti front-end script which initializes the terminal and listener threa
 
 import multiprocessing
 import cmd
-import json
-import os
 import serial.tools.list_ports
 import sys
-import datetime
 
 import serial.tools.list_ports_common
 
 from utils import help_strings
 from utils.constants import (
-    SAVE_DATA_DIR, SESSIONS_DIR, SESSION_FILE_FORMAT,
+    SESSIONS_DIR,
     NodeID, CmdID, COMM_INFO
 )
 
 from serial_reader import serial_reader
-from message_parser import log_messages, dict_to_yaml, Message
+from session_logger import log_messages, init_session_log, finalize_session_log
+from message import Message
 
 class ArgumentException(Exception): pass
 
@@ -162,57 +160,6 @@ class CommandLine(cmd.Cmd):
 # ----------------------------------------------------------
 # FUNCTIONS
 # ----------------------------------------------------------
-
-def init_session_log(port: str) -> str:
-    """Initializes the file which logs the session."""
-    if not os.path.exists(SAVE_DATA_DIR):
-        os.mkdir(SAVE_DATA_DIR)
-    if not os.path.exists(SESSIONS_DIR):
-        os.mkdir(SESSIONS_DIR)
-
-    session_start = datetime.datetime.now()
-
-    file_format = session_start.strftime(SESSION_FILE_FORMAT)
-    file_name = f"{file_format}.log"
-
-    date = session_start.strftime("%Y-%m-%d")
-    time = session_start.strftime("%H:%M:%S")
-
-    header_dict = {
-        "date": date,
-        "time": time,
-        "session-length": None,
-        "port": port,
-        "messages": ""
-    }
-
-    header = dict_to_yaml(header_dict, 0)
-
-    with open(SESSIONS_DIR / file_name, 'w', encoding="utf_8") as history:
-        history.write(header)
-
-    return file_name
-
-def finalize_session_log(file_name):
-    """Writes the session length to the log file."""
-    with open(SESSIONS_DIR / file_name, encoding="utf_8") as history:
-        log = history.read()
-
-    # get the datetime corresponding to the file name
-    session_start = datetime.datetime.strptime(file_name.strip(".log"), SESSION_FILE_FORMAT)
-
-    total_seconds = int((datetime.datetime.now() - session_start).total_seconds())
-    minutes, seconds = divmod(total_seconds, 60)
-    hours, minutes = divmod(minutes, 60)
-
-    # conditionally add hours and format the time
-    log = log.split("\n")
-    hours_str = f"{hours:02d}:" if hours else ""
-    log[2] = f"session-length: '{hours_str}{minutes:02d}:{seconds:02d}'"
-    log = "\n".join(log)
-
-    with open(SESSIONS_DIR / file_name, 'w', encoding="utf_8") as history:
-        history.write(log)
 
 def parse_send(args: str) -> tuple[str, str, dict, str]:
     """Parses arguments for `do_send`."""

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -30,7 +30,7 @@ class CommandLine(cmd.Cmd):
     # initialize the object
     def __init__(self, out_queue, write_queue, virtual_mode):
         super().__init__()
-        self.intro = "\nAvailable commands:\nsend\niamnow\nquery\nhelp\nlist\nexit\n"
+        self.intro = "\nAvailable commands:\nsend\niamnow\nhelp\nlist\nexit\n"
         self.prompt = ">> "
         self.out_msg_queue = out_queue
         self.write_msg_queue = write_queue
@@ -112,24 +112,6 @@ class CommandLine(cmd.Cmd):
                 print("Invalid sender ID.")
         except ValueError:
             print("Invalid args.")
-
-
-    """ def do_query(self, arg):
-        Queries the message history by command name.
-        print(f"\nSearching message history for {arg} commands...")
-
-        with open(SESSIONS_DIR / self.file_name, encoding="utf_8") as history:
-            log = history.read()
-
-        num_results = 0
-
-        lines = log.splitlines()
-        for line in lines:
-            line = line.strip()
-            if line.startswith("cmd: ") and line[5:] == arg:
-                num_results += 1
-
-        print(f"\nFound {num_results} results.\n") """
 
 
     def do_help(self, arg):

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -92,7 +92,7 @@ class CommandLine(cmd.Cmd):
                     buffer[arg_byte] = int(data[position:position+2], 16)
                     position += 2
 
-            msg = Message(buffer)
+            msg = Message(buffer, "user")
 
             print(f"\nCommand: {cmd_id.name}\nDestination: {dest_id.get_display_name()}")
 

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -13,7 +13,10 @@ import datetime
 import serial.tools.list_ports_common
 
 from utils import help_strings
-from utils.constants import SESSIONS_DIR, NodeID, CmdID, COMM_INFO, SESSION_FILE_FORMAT
+from utils.constants import (
+    SAVE_DATA_DIR, SESSIONS_DIR, SESSION_FILE_FORMAT,
+    NodeID, CmdID, COMM_INFO
+)
 
 from serial_reader import serial_reader
 from message_parser import log_messages, dict_to_yaml, Message
@@ -162,6 +165,8 @@ class CommandLine(cmd.Cmd):
 
 def init_session_log(port: str) -> str:
     """Initializes the file which logs the session."""
+    if not os.path.exists(SAVE_DATA_DIR):
+        os.mkdir(SAVE_DATA_DIR)
     if not os.path.exists(SESSIONS_DIR):
         os.mkdir(SESSIONS_DIR)
 

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -277,9 +277,10 @@ if __name__ == "__main__":
         write_msg_queue = multiprocessing.Queue() # messages to be written to file
         out_msg_queue = multiprocessing.Queue() # messages to send to SOTI board
 
-        if not selected_port is virtual_port:
+        if selected_port is not virtual_port:
             multiprocessing.Process(target=serial_reader, args=(write_msg_queue, out_msg_queue, selected_port.device), daemon=True).start()
-            multiprocessing.Process(target=parser, args=(write_msg_queue, output_file_name), daemon=True).start()
+        
+        multiprocessing.Process(target=parser, args=(write_msg_queue, output_file_name), daemon=True).start()
 
         CommandLine(out_msg_queue, write_msg_queue, output_file_name).cmdloop()
 

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -80,16 +80,16 @@ class CommandLine(cmd.Cmd):
             if dest_id is None:
                 raise ArgumentException(f"{cmd_id.name} requires a recipient")
 
-            if data:
-                # truncate extra numbers
-                data = data[:14]
-                # pad data with zeros to create a full message
-                data = data.ljust(14, "0")
+            # truncate excess data arguments
+            data = data[:14]
+            
+            # pad data with zeros to create a full message
+            data = data.ljust(14, "0")
 
             print(f"\nCommand: {cmd_id.name}\nDestination: {dest_id.get_display_name()}")
 
             # create a message using the arguments
-            msg = Message("user", priority, sender_id, dest_id, cmd_id, bytes.fromhex(data))
+            msg = Message(priority, sender_id, dest_id, cmd_id, bytes.fromhex(data), source="user")
 
             # send the message to be written to the serial device and logged
             self.out_msg_queue.put(msg)

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -5,19 +5,17 @@ The main soti front-end script which initializes the terminal and listener threa
 import multiprocessing
 import cmd
 import serial.tools.list_ports
-import sys
-
 import serial.tools.list_ports_common
 
 from utils import help_strings
 from utils.constants import (
-    SESSIONS_DIR,
     NodeID, CmdID, COMM_INFO
 )
 
 from serial_reader import serial_reader
-from session_logger import log_messages, init_session_log, finalize_session_log
+from session_logger import log_messages
 from message import Message
+
 
 class ArgumentException(Exception): pass
 

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -28,13 +28,12 @@ class ArgumentException(Exception): pass
 class CommandLine(cmd.Cmd):
     """Represents the command line interface."""
     # initialize the object
-    def __init__(self, out_queue, write_queue, virtual_mode):
+    def __init__(self, out_queue, write_queue):
         super().__init__()
         self.intro = "\nAvailable commands:\nsend\niamnow\nhelp\nlist\nexit\n"
         self.prompt = ">> "
         self.out_msg_queue = out_queue
         self.write_msg_queue = write_queue
-        self.virtual_mode = virtual_mode
         self.sender_id = NodeID.CDH
 
 
@@ -93,8 +92,7 @@ class CommandLine(cmd.Cmd):
 
             # send the message to be written to the serial device and logged
             self.write_msg_queue.put(msg)
-            if not virtual_mode:
-                self.out_msg_queue.put(msg)
+            self.out_msg_queue.put(msg)
 
         except ArgumentException as e:
             print(e)
@@ -244,7 +242,7 @@ if __name__ == "__main__":
         for p in processes:
             p.start()
 
-        CommandLine(out_msg_queue, write_msg_queue, virtual_mode).cmdloop()
+        CommandLine(out_msg_queue, write_msg_queue).cmdloop()
 
     except KeyboardInterrupt:
         pass

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -80,26 +80,21 @@ class CommandLine(cmd.Cmd):
             if dest_id is None:
                 raise ArgumentException(f"{cmd_id.name} requires a recipient")
 
-            # create buffer with empty payload
-            buffer = bytearray([priority, sender_id.value, dest_id.value, cmd_id.value] + [0] * 7)
-
             if data:
+                # truncate extra numbers
+                data = data[:14]
                 # pad data with zeros to create a full message
                 data = data.ljust(14, "0")
 
-                # fill the buffer with the data bytes
-                position = 0
-                for arg_byte in range(4,11):
-                    buffer[arg_byte] = int(data[position:position+2], 16)
-                    position += 2
-
-            msg = Message(buffer, "user")
-
             print(f"\nCommand: {cmd_id.name}\nDestination: {dest_id.get_display_name()}")
 
-            # send the command + arguments to the serial handler to write to the serial device
+            # create a message using the arguments
+            msg = Message("user", priority, sender_id, dest_id, cmd_id, bytes.fromhex(data))
+
+            # send the message to be written to the serial device and logged
             self.out_msg_queue.put(msg)
             self.write_msg_queue.put(msg)
+
 
         except ArgumentException as e:
             print(e)

--- a/soti/message.py
+++ b/soti/message.py
@@ -1,0 +1,29 @@
+import datetime
+from utils.constants import CmdID, NodeID
+from session_logger import parse_msg_body
+
+class Message:
+    def __init__(self, msg_bytes: bytes, source: str):
+        """Initialize the message from a bytes object."""
+        self.bytes = msg_bytes
+        # serial parameters
+        self.priority = msg_bytes[0]
+        self.sender = NodeID(msg_bytes[1])
+        self.recipient = NodeID(msg_bytes[2])
+        self.cmd_id = CmdID(msg_bytes[3])
+        self.body = msg_bytes[4:]
+        # additional parameters
+        self.time = datetime.datetime.now().strftime("%T")
+        self.source = source
+        
+    def as_dict(self) -> dict:
+        """Return the message parameters as a dictionary."""
+        return {
+            "time": self.time,
+            "source": self.source,
+            "priority": self.priority,
+            "sender-id": self.sender,
+            "recipient-id": self.recipient,
+            "cmd": self.cmd_id,
+            "body": parse_msg_body(self.cmd_id, self.body)
+        }

--- a/soti/message.py
+++ b/soti/message.py
@@ -1,20 +1,41 @@
-import datetime
+from datetime import datetime
+from dataclasses import dataclass, field
 from utils.constants import CmdID, NodeID
 from session_logger import parse_msg_body
 
+@dataclass
 class Message:
-    def __init__(self, msg_bytes: bytes, source: str):
-        """Initialize the message from a bytes object."""
-        self.bytes = msg_bytes
-        # serial parameters
-        self.priority = msg_bytes[0]
-        self.sender = NodeID(msg_bytes[1])
-        self.recipient = NodeID(msg_bytes[2])
-        self.cmd_id = CmdID(msg_bytes[3])
-        self.body = msg_bytes[4:]
-        # additional parameters
-        self.time = datetime.datetime.now().strftime("%T")
-        self.source = source
+    source: str
+    priority: int
+    sender: NodeID
+    recipient: NodeID
+    cmd_id: CmdID
+    body: bytes = field(default_factory=([0] * 7))
+    time: datetime = field(default_factory=
+        lambda:datetime.now().strftime("%T")
+    )
+
+    @classmethod
+    def deserialize(cls, source, msg_bytes: bytes) -> "Message":
+        """Create a message from serialized bytes."""
+        source = source
+        priority = msg_bytes[0]
+        sender = NodeID(msg_bytes[1])
+        recipient = NodeID(msg_bytes[2])
+        cmd_id = CmdID(msg_bytes[3])
+        body = msg_bytes[4:]
+
+        return cls(source, priority, sender, recipient, cmd_id, body)
+
+    def serialize(self) -> bytes:
+        """Return the serialized bytes of the message."""
+        return bytes(bytearray([
+            self.priority,
+            self.sender.value,
+            self.recipient.value,
+            self.cmd_id.value])
+            + self.body
+        )
         
     def as_dict(self) -> dict:
         """Return the message parameters as a dictionary."""

--- a/soti/message.py
+++ b/soti/message.py
@@ -5,27 +5,28 @@ from session_logger import parse_msg_body
 
 @dataclass
 class Message:
-    source: str
+    # serial parameters
     priority: int
     sender: NodeID
     recipient: NodeID
     cmd_id: CmdID
     body: bytes = field(default_factory=([0] * 7))
+    # additional parameters
+    source: str = field(default="unspecified")
     time: datetime = field(default_factory=
-        lambda:datetime.now().strftime("%T")
+        lambda: datetime.now().strftime("%T")
     )
 
     @classmethod
-    def deserialize(cls, source, msg_bytes: bytes) -> "Message":
+    def deserialize(cls, msg_bytes: bytes) -> "Message":
         """Create a message from serialized bytes."""
-        source = source
         priority = msg_bytes[0]
         sender = NodeID(msg_bytes[1])
         recipient = NodeID(msg_bytes[2])
         cmd_id = CmdID(msg_bytes[3])
         body = msg_bytes[4:]
 
-        return cls(source, priority, sender, recipient, cmd_id, body)
+        return cls(priority, sender, recipient, cmd_id, body)
 
     def serialize(self) -> bytes:
         """Return the serialized bytes of the message."""

--- a/soti/message_parser.py
+++ b/soti/message_parser.py
@@ -6,7 +6,7 @@ from enum import Enum
 from utils.constants import NodeID, CmdID, SESSIONS_DIR
 
 class Message:
-    def __init__(self, msg_bytes: bytes):
+    def __init__(self, msg_bytes: bytes, source: str):
         """Initialize the message from a bytes object."""
         self.bytes = msg_bytes
         # serial parameters
@@ -17,11 +17,13 @@ class Message:
         self.body = msg_bytes[4:]
         # additional parameters
         self.time = datetime.datetime.now().strftime("%T")
+        self.source = source
         
     def as_dict(self) -> dict:
         """Return the message parameters as a dictionary."""
         return {
             "time": self.time,
+            "source": self.source,
             "priority": self.priority,
             "sender-id": self.sender,
             "recipient-id": self.recipient,

--- a/soti/message_parser.py
+++ b/soti/message_parser.py
@@ -3,19 +3,19 @@
 import datetime
 import json
 import struct
-from utils.constants import NodeID, CmdID, MSG_HISTORY_PATH
+from utils.constants import NodeID, CmdID, SAVE_DATA_DIR
 
 
-def parser(write_msg_queue):
+def parser(write_msg_queue, output_file):
     """Gets messages from the incoming queue and parses them"""
     while True:
         new_msg_raw = write_msg_queue.get()
         new_msg_json = parse_message(new_msg_raw)
         print(f"Message Parsed: {new_msg_json}")
-        with open(MSG_HISTORY_PATH, encoding="utf_8") as history:
+        with open(SAVE_DATA_DIR / output_file, encoding="utf_8") as history:
             history_json = json.load(history)
-        history_json.append(new_msg_json)
-        with open(MSG_HISTORY_PATH, 'w', encoding="utf_8") as history:
+        history_json["messages"].append(new_msg_json)
+        with open(SAVE_DATA_DIR / output_file, 'w', encoding="utf_8") as history:
             json.dump(history_json, history, indent=4)
 
 def parse_message(msg: bytes):

--- a/soti/message_parser.py
+++ b/soti/message_parser.py
@@ -3,7 +3,7 @@
 import datetime
 import struct
 from enum import Enum
-from utils.constants import NodeID, CmdID, SAVE_DATA_DIR
+from utils.constants import NodeID, CmdID, SESSIONS_DIR
 
 
 def parser(write_msg_queue, output_file_name):
@@ -13,12 +13,12 @@ def parser(write_msg_queue, output_file_name):
         new_msg_json = parse_message(new_msg_raw)
         print(f"Message Parsed: {new_msg_json}")
 
-        with open(SAVE_DATA_DIR / output_file_name, encoding="utf_8") as history:
+        with open(SESSIONS_DIR / output_file_name, encoding="utf_8") as history:
             log = history.read()
 
         log += dict_to_yaml(new_msg_json, 1, True) + "\n"
 
-        with open(SAVE_DATA_DIR / output_file_name, 'w', encoding="utf_8") as history:
+        with open(SESSIONS_DIR / output_file_name, 'w', encoding="utf_8") as history:
             history.write(log)
 
 def parse_message(msg: bytes):

--- a/soti/message_parser.py
+++ b/soti/message_parser.py
@@ -37,7 +37,8 @@ def log_messages(write_msg_queue, output_file_name):
     while True:
         new_msg = write_msg_queue.get()
         new_msg_dict = new_msg.as_dict()
-        print(f"Message Parsed: {new_msg_dict}")
+        if new_msg.source == "port":
+            print(f"Message Parsed: {new_msg_dict}")
 
         with open(SESSIONS_DIR / output_file_name, encoding="utf_8") as history:
             log = history.read()

--- a/soti/message_parser.py
+++ b/soti/message_parser.py
@@ -6,10 +6,10 @@ import struct
 from utils.constants import NodeID, CmdID, MSG_HISTORY_PATH
 
 
-def parser(in_msg_queue):
+def parser(write_msg_queue):
     """Gets messages from the incoming queue and parses them"""
     while True:
-        new_msg_raw = in_msg_queue.get()
+        new_msg_raw = write_msg_queue.get()
         new_msg_json = parse_message(new_msg_raw)
         print(f"Message Parsed: {new_msg_json}")
         with open(MSG_HISTORY_PATH, encoding="utf_8") as history:
@@ -17,7 +17,6 @@ def parser(in_msg_queue):
         history_json.append(new_msg_json)
         with open(MSG_HISTORY_PATH, 'w', encoding="utf_8") as history:
             json.dump(history_json, history, indent=4)
-
 
 def parse_message(msg: bytes):
     """Parses a message."""
@@ -31,12 +30,12 @@ def parse_message(msg: bytes):
     parsed_msg = {
         "time": datetime.datetime.now().strftime("%T"),
         "priority": priority,
-        "sender-id": sender,
-        "recipient-id": recipient,
+        "sender-id": sender.name,
+        "recipient-id": recipient.name,
         "cmd": cmd_id.name,
     }
 
-    parsed_msg.body = parse_msg_body(cmd_id, body)
+    parsed_msg["body"] = parse_msg_body(cmd_id, body)
 
     return parsed_msg
 

--- a/soti/message_parser.py
+++ b/soti/message_parser.py
@@ -6,16 +6,16 @@ import struct
 from utils.constants import NodeID, CmdID, SAVE_DATA_DIR
 
 
-def parser(write_msg_queue, output_file):
+def parser(write_msg_queue, output_file_name):
     """Gets messages from the incoming queue and parses them"""
     while True:
         new_msg_raw = write_msg_queue.get()
         new_msg_json = parse_message(new_msg_raw)
         print(f"Message Parsed: {new_msg_json}")
-        with open(SAVE_DATA_DIR / output_file, encoding="utf_8") as history:
+        with open(SAVE_DATA_DIR / output_file_name, encoding="utf_8") as history:
             history_json = json.load(history)
         history_json["messages"].append(new_msg_json)
-        with open(SAVE_DATA_DIR / output_file, 'w', encoding="utf_8") as history:
+        with open(SAVE_DATA_DIR / output_file_name, 'w', encoding="utf_8") as history:
             json.dump(history_json, history, indent=4)
 
 def parse_message(msg: bytes):

--- a/soti/serial_reader.py
+++ b/soti/serial_reader.py
@@ -17,7 +17,8 @@ def serial_reader(write_msg_queue, out_msg_queue, soti_port):
                 new_msg_bytes = ser.read(MSG_SIZE)
                 new_msg_hex = new_msg_bytes.hex()
                 print(f"New Message: 0x{new_msg_hex}")
-                new_msg = Message.deserialize("port", new_msg_bytes)
+                new_msg = Message.deserialize(new_msg_bytes)
+                new_msg.source = "port"
                 write_msg_queue.put(new_msg)
 
             # check for outgoing messages

--- a/soti/serial_reader.py
+++ b/soti/serial_reader.py
@@ -6,28 +6,40 @@ from utils.constants import MSG_SIZE
 from message import Message
 
 
-def serial_reader(write_msg_queue, out_msg_queue, soti_port):
+def serial_reader(write_msg_queue, out_msg_queue, stop_pipe, soti_port):
     """Handles incoming and outgoing serial messages."""
-    # use a write timeout of 1 second to avoid infinite blocking
-    with serial.Serial(soti_port, baudrate=115200, write_timeout=1) as ser:
-        while True:
-            # check for incoming messages
-            while ser.in_waiting >= MSG_SIZE:
-                # block and read indefinitely, reading messages 11 bytes at a time
-                new_msg_bytes = ser.read(MSG_SIZE)
-                new_msg_hex = new_msg_bytes.hex()
-                print(f"New Message: 0x{new_msg_hex}")
-                new_msg = Message.deserialize(new_msg_bytes)
-                new_msg.source = "port"
-                write_msg_queue.put(new_msg)
+    try:
+        # use a write timeout of 1 second to avoid infinite blocking
+        with serial.Serial(soti_port, baudrate=115200, write_timeout=1) as ser:
+            while True:
+                if stop_pipe.poll():
+                    break
 
-            # check for outgoing messages
-            try:
-                # write the appropriate command + arguments to the serial device
-                out_msg = out_msg_queue.get(block=False).serialize()
-                print(f"Sending bytes to the satellite: 0x{out_msg.hex().upper()}")
-                ser.write(out_msg)
-            except Empty:
-                pass
-            except serial.SerialTimeoutException:
-                print("Send Fail: Serial write timed out.")
+                # check for incoming messages
+                while ser.in_waiting >= MSG_SIZE:
+                    # block and read indefinitely, reading messages 11 bytes at a time
+                    new_msg_bytes = ser.read(MSG_SIZE)
+                    new_msg_hex = new_msg_bytes.hex()
+                    print(f"New Message: 0x{new_msg_hex}")
+                    new_msg = Message.deserialize(new_msg_bytes)
+                    new_msg.source = "port"
+                    write_msg_queue.put(new_msg)
+
+                # check for outgoing messages
+                try:
+                    # write the appropriate command + arguments to the serial device
+                    out_msg = out_msg_queue.get(block=False).serialize()
+                    print(f"Sending bytes to the satellite: 0x{out_msg.hex().upper()}")
+                    ser.write(out_msg)
+                except Empty:
+                    pass
+                except serial.SerialTimeoutException:
+                    print("Send Fail: Serial write timed out.")
+
+    except KeyboardInterrupt:
+        # abort the remaining messages
+        while not out_msg_queue.empty():
+            out_msg_queue.get()
+
+    finally:
+        stop_pipe.close()

--- a/soti/serial_reader.py
+++ b/soti/serial_reader.py
@@ -6,15 +6,12 @@ from utils.constants import MSG_SIZE
 from message import Message
 
 
-def serial_reader(write_msg_queue, out_msg_queue, stop_pipe, soti_port):
+def serial_reader(write_msg_queue, out_msg_queue, stop_flag, soti_port):
     """Handles incoming and outgoing serial messages."""
     try:
         # use a write timeout of 1 second to avoid infinite blocking
         with serial.Serial(soti_port, baudrate=115200, write_timeout=1) as ser:
-            while True:
-                if stop_pipe.poll():
-                    break
-
+            while not stop_flag.is_set():
                 # check for incoming messages
                 while ser.in_waiting >= MSG_SIZE:
                     # block and read indefinitely, reading messages 11 bytes at a time
@@ -35,11 +32,5 @@ def serial_reader(write_msg_queue, out_msg_queue, stop_pipe, soti_port):
                     pass
                 except serial.SerialTimeoutException:
                     print("Send Fail: Serial write timed out.")
-
     except KeyboardInterrupt:
-        # abort the remaining messages
-        while not out_msg_queue.empty():
-            out_msg_queue.get()
-
-    finally:
-        stop_pipe.close()
+        pass

--- a/soti/serial_reader.py
+++ b/soti/serial_reader.py
@@ -17,13 +17,13 @@ def serial_reader(write_msg_queue, out_msg_queue, soti_port):
                 new_msg_bytes = ser.read(MSG_SIZE)
                 new_msg_hex = new_msg_bytes.hex()
                 print(f"New Message: 0x{new_msg_hex}")
-                new_msg = Message(new_msg_bytes, "port")
+                new_msg = Message.deserialize("port", new_msg_bytes)
                 write_msg_queue.put(new_msg)
 
             # check for outgoing messages
             try:
                 # write the appropriate command + arguments to the serial device
-                out_msg = out_msg_queue.get(block=False).bytes
+                out_msg = out_msg_queue.get(block=False).serialize()
                 print(f"Sending bytes to the satellite: 0x{out_msg.hex().upper()}")
                 ser.write(out_msg)
             except Empty:

--- a/soti/serial_reader.py
+++ b/soti/serial_reader.py
@@ -17,7 +17,7 @@ def serial_reader(write_msg_queue, out_msg_queue, soti_port):
                 new_msg_bytes = ser.read(MSG_SIZE)
                 new_msg_hex = new_msg_bytes.hex()
                 print(f"New Message: 0x{new_msg_hex}")
-                new_msg = Message(new_msg_bytes)
+                new_msg = Message(new_msg_bytes, "port")
                 write_msg_queue.put(new_msg)
 
             # check for outgoing messages

--- a/soti/serial_reader.py
+++ b/soti/serial_reader.py
@@ -3,6 +3,7 @@
 from queue import Empty
 import serial
 from utils.constants import MSG_SIZE
+from message_parser import Message
 
 
 def serial_reader(write_msg_queue, out_msg_queue, soti_port):
@@ -13,15 +14,16 @@ def serial_reader(write_msg_queue, out_msg_queue, soti_port):
             # check for incoming messages
             while ser.in_waiting >= MSG_SIZE:
                 # block and read indefinitely, reading messages 11 bytes at a time
-                new_msg = ser.read(MSG_SIZE)
-                new_msg_hex = new_msg.hex()
+                new_msg_bytes = ser.read(MSG_SIZE)
+                new_msg_hex = new_msg_bytes.hex()
                 print(f"New Message: 0x{new_msg_hex}")
+                new_msg = Message(new_msg_bytes)
                 write_msg_queue.put(new_msg)
 
             # check for outgoing messages
             try:
                 # write the appropriate command + arguments to the serial device
-                out_msg = out_msg_queue.get(block=False)
+                out_msg = out_msg_queue.get(block=False).bytes
                 print(f"Sending bytes to the satellite: 0x{out_msg.hex().upper()}")
                 ser.write(out_msg)
             except Empty:

--- a/soti/serial_reader.py
+++ b/soti/serial_reader.py
@@ -6,11 +6,11 @@ from utils.constants import MSG_SIZE
 from message import Message
 
 
-def serial_reader(write_msg_queue, out_msg_queue, stop_flag, soti_port):
+def serial_reader(write_msg_queue, out_msg_queue, stop_flag, port):
     """Handles incoming and outgoing serial messages."""
     try:
         # use a write timeout of 1 second to avoid infinite blocking
-        with serial.Serial(soti_port, baudrate=115200, write_timeout=1) as ser:
+        with serial.Serial(port, baudrate=115200, write_timeout=1) as ser:
             while not stop_flag.is_set():
                 # check for incoming messages
                 while ser.in_waiting >= MSG_SIZE:

--- a/soti/serial_reader.py
+++ b/soti/serial_reader.py
@@ -3,7 +3,7 @@
 from queue import Empty
 import serial
 from utils.constants import MSG_SIZE
-from message_parser import Message
+from message import Message
 
 
 def serial_reader(write_msg_queue, out_msg_queue, soti_port):

--- a/soti/serial_reader.py
+++ b/soti/serial_reader.py
@@ -5,7 +5,7 @@ import serial
 from utils.constants import MSG_SIZE
 
 
-def serial_reader(in_msg_queue, out_msg_queue, soti_port):
+def serial_reader(write_msg_queue, out_msg_queue, soti_port):
     """Handles incoming and outgoing serial messages."""
     # use a write timeout of 1 second to avoid infinite blocking
     with serial.Serial(soti_port, baudrate=115200, write_timeout=1) as ser:
@@ -16,7 +16,7 @@ def serial_reader(in_msg_queue, out_msg_queue, soti_port):
                 new_msg = ser.read(MSG_SIZE)
                 new_msg_hex = new_msg.hex()
                 print(f"New Message: 0x{new_msg_hex}")
-                in_msg_queue.put(new_msg)
+                write_msg_queue.put(new_msg)
 
             # check for outgoing messages
             try:

--- a/soti/session_logger.py
+++ b/soti/session_logger.py
@@ -128,7 +128,7 @@ def to_bin_str(data: bytes) -> str:
     """Returns a binary representation of the provided data."""
     bit_string = ''
     for byte in data:
-        bits = bin(byte)[2:]  # remove '0b' prefix
+        bits = str(bin(byte))[2:]  # remove '0b' prefix
         bit_string += bits.zfill(8)  # pad with zeros to 8 bits
     return "0b" + bit_string
 

--- a/soti/utils/constants.py
+++ b/soti/utils/constants.py
@@ -10,7 +10,7 @@ SAVE_DATA_DIR = ROOT_DIR / "save-data"
 SESSIONS_DIR = SAVE_DATA_DIR / "sessions"
 
 # Used to name session files with datetime.strftime()
-SESSION_FILE_FORMAT = "%Y-%m-%d_%H-%M-%S"
+SESSION_FILE_FORMAT = "%Y-%m-%d_%H%M%S"
 
 # The length of a serialized message in bytes.
 MSG_SIZE = 11

--- a/soti/utils/constants.py
+++ b/soti/utils/constants.py
@@ -9,6 +9,8 @@ SAVE_DATA_DIR = ROOT_DIR / "save-data"
 
 MSG_HISTORY_PATH = SAVE_DATA_DIR / "messages.json"
 
+SESSION_FILE_FORMAT = "%Y-%m-%d_%H-%M-%S"
+
 # The length of a serialized message in bytes.
 MSG_SIZE = 11
 

--- a/soti/utils/constants.py
+++ b/soti/utils/constants.py
@@ -7,8 +7,9 @@ ROOT_DIR = Path(__file__).resolve().parent.parent
 
 SAVE_DATA_DIR = ROOT_DIR / "save-data"
 
-MSG_HISTORY_PATH = SAVE_DATA_DIR / "messages.json"
+SESSIONS_DIR = SAVE_DATA_DIR / "sessions"
 
+# Used to name session files with datetime.strftime()
 SESSION_FILE_FORMAT = "%Y-%m-%d_%H-%M-%S"
 
 # The length of a serialized message in bytes.

--- a/soti/utils/help_strings.py
+++ b/soti/utils/help_strings.py
@@ -6,7 +6,6 @@ from utils.constants import CmdID
 HELP_MESSAGE = """
 send: sends a command to the satellite
 iamnow: sets the default sender ID of sent commands
-query: queries the message history by command name
 help: displays this message
 list: lists the available commands for each subsystem
 exit: exits the program

--- a/soti/utils/help_strings.py
+++ b/soti/utils/help_strings.py
@@ -6,8 +6,7 @@ from utils.constants import CmdID
 HELP_MESSAGE = """
 send: sends a command to the satellite
 iamnow: sets the default sender ID of sent commands
-query: queries the satellite's message history for information
-clear: clears the json message history file
+query: queries the message history by command name
 help: displays this message
 list: lists the available commands for each subsystem
 exit: exits the program


### PR DESCRIPTION
**Features:**
Both incoming and outgoing messages are recorded to a log file in YAML format. This log file also contains info about the session: Its starting date and time, its length, and the port used. These files are stored in `/save-data/sessions` with the file name being a timestamp (ex. `2024-10-16_153006.log`).

Removes the `clear` command (I'm assuming it's not needed anymore). Also fixes `query` so you can query by command name (ex. `>> query PLD_SET_ACTIVE_ENVS`).

**Notes:**
Effectively renamed `in_msg_queue` to `write_msg_queue`, there's not much difference in functionality aside from the outgoing messages being written to both the `write` and `out` queue.

Renamed `parser()` to `log_messages()`, since its purpose is only to write to the file now.

Added a little `Message` class for simplification. The queues hold Messages so data aside from the serialized bytes can be accessed.

**TODO:**
- [x] Any other suggestions for the file naming and extension (`.log`)?
- [x] A "sent from SOTI" flag might make reading the logs easier.
- [x] The "message parsed" output shows up when sending a message, which isn't useful. It could be hidden based on the flag mentioned above ~~or it could be formatted better (maybe just by using `dict_to_yaml()`) and also solve #31~~.
- [ ] Suggestions from [this comment](https://github.com/UMSATS/soti/pull/37#issuecomment-2438858373).