### PR TITLE
Feat: Better Argument Parsing

### DIFF
--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -148,15 +148,21 @@ def parse_send(args: str) -> tuple[str, str, dict, str]:
                 options[key] = value
             # else treat as data argument
             else:
-                value = format(int(part, 16), 'x')
-                # restore leading zeroes
-                data += value.zfill(len(part) - (2 if '0x' in part else 0))
+                # value is a hex string (ex. "7b")
+                value = format(parse_int(part), 'x')
+                # add zeros to match nearest int size (8, 16, 32 bits)
+                digits = len(value)
+                target_digits = 2
+                while target_digits < digits: target_digits *= 2
+                value = value.rjust(target_digits, "0")
+                # append value to data
+                data += value
         except ValueError:
             error = f"Unknown argument '{part}'"
     
     return cmd_id, data, options, error
 
-def parse_int(i, base = 10) -> int:
+def parse_int(i) -> int:
     """Casts numbers and enum members to int."""
     try:
         if isinstance(i, int):

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -156,6 +156,8 @@ def parse_send(args: str) -> tuple[str, str, dict, str]:
                 if part[:2] == "0b":
                     # subtract prefix and round up
                     digits = (len(part) - 2 + 3) // 4
+                elif part[:2] == "0x":
+                    digits = (len(part) - 2)
                 else:
                     digits = len(value)
                 target_digits = 2

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -207,7 +207,7 @@ def parse_send(args: str) -> tuple[bytes, str, dict, str]:
                     value *= -1
 
                 # create a bytes object
-                value = int(value).to_bytes(bytes_length, signed=signed)
+                value = int(value).to_bytes(bytes_length, byteorder="little", signed=signed)
                 # insert the value into data
                 end_index = data_index + bytes_length
                 data[data_index : end_index] = value

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -146,17 +146,25 @@ def parse_send(args: str) -> tuple[str, str, dict, str]:
             if '=' in part:  
                 key, value = part.split('=')
                 options[key] = value
+
             # else treat as data argument
             else:
                 # value is a hex string (ex. "7b")
                 value = format(parse_int(part), 'x')
+
                 # add zeros to match nearest int size (8, 16, 32 bits)
-                digits = len(value)
+                if part[:2] == "0b":
+                    # subtract prefix and round up
+                    digits = (len(part) - 2 + 3) // 4
+                else:
+                    digits = len(value)
                 target_digits = 2
                 while target_digits < digits: target_digits *= 2
                 value = value.rjust(target_digits, "0")
+
                 # append value to data
                 data += value
+
         except ValueError:
             error = f"Unknown argument '{part}'"
     

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -9,15 +9,14 @@ import serial.tools.list_ports_common
 
 from utils import help_strings
 from utils.constants import (
-    NodeID, CmdID, COMM_INFO, DATA_SIZE
+    NodeID, CmdID, COMM_INFO
 )
 
 from serial_reader import serial_reader
 from session_logger import log_messages
 from message import Message
+import parser
 
-
-class ArgumentException(Exception): pass
 
 # ----------------------------------------------------------
 # CMD CLASS
@@ -38,38 +37,38 @@ class CommandLine(cmd.Cmd):
     def do_send(self, arg):
         """Sends a command."""
         try:
-            cmd_str, data, options = parse_send(arg)
-            
+            cmd_str, data, options = (arg)
+
             # get corresponding CmdID
             try:
-                cmd_id = CmdID(parse_int(cmd_str))
+                cmd_id = CmdID(parser.parse_int(cmd_str))
             except ValueError:
-                raise ArgumentException("Invalid command ID")
+                raise parser.ArgumentException("Invalid command ID")
 
             # get the default values for the command
             priority = COMM_INFO[cmd_id]["priority"]
             sender_id = self.sender_id
             dest_id = COMM_INFO[cmd_id]["dest"]
-            
+
             # override defaults with optional arguments
             for key in options:
                 if key == "priority":
-                    priority = parse_int(options["priority"])
-                
+                    priority = parser.parse_int(options["priority"])
+
                 try:
                     if key == "from":
-                        sender_id = NodeID(parse_int(options["from"]))
+                        sender_id = NodeID(parser.parse_int(options["from"]))
                     if key == "to":
-                        dest_id = NodeID(parse_int(options["to"]))
+                        dest_id = NodeID(parser.parse_int(options["to"]))
                 except (ValueError, KeyError):
-                    raise ArgumentException("Invalid node ID")
-            
+                    raise parser.ArgumentException("Invalid node ID")
+
             # raise exceptions for invalid arguments
             if not (0 <= priority <= 32):
-                raise ArgumentException("Invalid priority")
-            
+                raise parser.ArgumentException("Invalid priority")
+
             if dest_id is None:
-                raise ArgumentException(f"{cmd_id.name} requires a recipient")
+                raise parser.ArgumentException(f"{cmd_id.name} requires a recipient")
 
             print(f"\nCommand: {cmd_id.name}\nDestination: {dest_id.get_display_name()}")
 
@@ -80,7 +79,7 @@ class CommandLine(cmd.Cmd):
             self.write_msg_queue.put(msg)
             self.out_msg_queue.put(msg)
 
-        except (ValueError, ArgumentException) as e:
+        except (ValueError, parser.ArgumentException) as e:
             print(e)
             return
 
@@ -88,7 +87,7 @@ class CommandLine(cmd.Cmd):
     def do_iamnow(self, arg):
         """Changes the default sender ID."""
         try:
-            node_id = NodeID(parse_int(arg))
+            node_id = NodeID(parser.parse_int(arg))
             if node_id in NodeID:
                 self.sender_id = node_id
                 print(f"Updated sender ID to {self.sender_id.get_display_name()}.")
@@ -117,137 +116,6 @@ class CommandLine(cmd.Cmd):
         """Exits the CLI."""
         return True
 
-
-# ----------------------------------------------------------
-# FUNCTIONS
-# ----------------------------------------------------------
-
-def parse_send(args: str) -> tuple[bytes, str, dict, str]:
-    """Parses arguments for `do_send`."""
-    parts = args.split()
-
-    cmd_id = parts[0]
-    data = bytearray(DATA_SIZE)
-    data_index = 0
-    options = {}
-
-    for index, part in enumerate(parts[1:]):
-        arg = part
-        try:
-            # check if key-value pair
-            if '=' in arg:  
-                key, value = arg.split('=')
-                options[key] = value
-
-            # treat as data argument
-            elif data_index < DATA_SIZE:
-                # check if integer type was provided
-                explicit_type = arg[0] == "("
-
-                if explicit_type:
-                    type_end = arg.find(")")
-                    if type_end <= 0: 
-                        raise ValueError()
-
-                    type = arg[1 : type_end]
-
-                    # only signed if first character is "i"
-                    explicit_sign = not type[0].isnumeric()
-                    signed = type[0] == "i" if explicit_sign else False
-
-                    # slice from 1 if sign was provided
-                    target_size = int(type[int(explicit_sign):]) // 8
-
-                    # remove the cast from the argument
-                    arg = arg[type_end + 1 :]
-
-                negative = arg[0] == "-"
-                if negative: 
-                    # remove negative sign
-                    arg = arg[1:]
-
-                if not explicit_type:
-                    # defaults to unsigned unless negative
-                    signed = negative
-
-                    # determine minimum byte size to store the number
-                    if arg[:2] == "0b":
-                        size = (len(arg) - 2 + 7) // 8
-                    elif arg[:2] == "0x":
-                        size = (len(arg) - 2 + 1) // 2
-                    else: # decimal
-                        size = (len(format(parse_int(arg), 'x')) + 1) // 2
-
-                    # determine nearest integer width (1, 2, 4 bytes)
-                    target_size = 1
-                    while target_size < size: target_size *= 2
-
-                # value is the absolute value of the number
-                value = parse_int(arg)
-
-                max_unsigned = 2 ** (target_size * 8) - 1
-                max_signed = max_unsigned // 2
-
-                # handle overflows based on signedness
-                if value > max_unsigned:
-                    raise ArgumentException(f"Overflow from {part}")
-                elif not signed and negative:
-                    raise ArgumentException(f"{part} cannot be unsigned and negative")
-                
-                elif signed and value > max_signed:
-                    if not negative:
-                        # overflow to negative two's complement
-                        value = value - max_unsigned - 1
-                    elif value > max_signed + 1:
-                        # negative underflow
-                        raise ArgumentException(f"Underflow from {part}")
-
-                if negative:
-                    value *= -1
-
-                # create a bytes object
-                value = int(value).to_bytes(target_size, byteorder="little", signed=signed)
-                # insert the value into data
-                end_index = data_index + target_size
-                data[data_index : end_index] = value
-                data_index = end_index
-
-        except ValueError:
-            raise ArgumentException(f"Invalid argument '{part}'")
-        except IndexError:
-            raise ArgumentException(f"Invalid syntax: {part}")
-        except ArgumentException as e:
-            raise ArgumentException(e) from e
-
-    # truncate extra bytes
-    data = data[:DATA_SIZE]
-
-    return cmd_id, bytes(data), options
-
-def parse_int(i) -> int:
-    """
-    Casts numbers and enum members to int.
-    Raises ValueError for invalid values.
-    """
-    try:
-        if isinstance(i, int):
-            return i
-        elif isinstance(i, str):
-            if i.isnumeric():
-                return int(i)
-            if i[:2] == "0x":
-                return int(i, 16)
-            if i[:2] == "0b":
-                return int(i, 2)
-            if i in NodeID.__members__:
-                return NodeID[i].value
-            if i in CmdID.__members__:
-                return CmdID[i].value
-        # no valid cast
-        raise ValueError()
-    except (ValueError) as e:
-        # raises an exception for the caller
-        raise ValueError(e) from e
 
 # ----------------------------------------------------------
 # MAIN APPLICATION CODE

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -89,7 +89,7 @@ class CommandLine(cmd.Cmd):
             self.write_msg_queue.put(msg)
             self.out_msg_queue.put(msg)
 
-        except ArgumentException as e:
+        except (ValueError, ArgumentException) as e:
             print(e)
             return
 
@@ -173,9 +173,11 @@ def parse_int(i, base = 10) -> int:
             if i in CmdID.__members__:
                 return CmdID[i].value
         else:
-            raise ArgumentException # no valid cast
-    except (ValueError, ArgumentException) as e:
-        return e
+            # no valid cast
+            raise ValueError()
+    except (ValueError) as e:
+        # raises an exception for the caller
+        raise ValueError(e) from e
 
 # ----------------------------------------------------------
 # MAIN APPLICATION CODE

--- a/soti/__main__.py
+++ b/soti/__main__.py
@@ -37,7 +37,7 @@ class CommandLine(cmd.Cmd):
     def do_send(self, arg):
         """Sends a command."""
         try:
-            cmd_str, data, options = (arg)
+            cmd_str, data, options = parser.parse_send(arg)
 
             # get corresponding CmdID
             try:

--- a/soti/message.py
+++ b/soti/message.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from dataclasses import dataclass, field
-from utils.constants import CmdID, NodeID
+from utils.constants import DATA_SIZE, CmdID, NodeID
 from session_logger import parse_msg_body
 
 @dataclass
@@ -30,14 +30,22 @@ class Message:
 
     def serialize(self) -> bytes:
         """Return the serialized bytes of the message."""
+        # Ensure the data field is the correct length.
+        data = bytearray(self.body)
+        if len(data) > DATA_SIZE:
+            return data[:DATA_SIZE]  # Truncate to the specified length
+        elif len(data) < DATA_SIZE:
+            return data + bytearray(DATA_SIZE - len(data))  # Extend with zeroes
+
         return bytes(bytearray([
             self.priority,
             self.sender.value,
             self.recipient.value,
             self.cmd_id.value])
-            + self.body
+            + data
         )
-        
+
+
     def as_dict(self) -> dict:
         """Return the message parameters as a dictionary."""
         return {

--- a/soti/message.py
+++ b/soti/message.py
@@ -17,6 +17,14 @@ class Message:
         lambda: datetime.now().strftime("%T")
     )
 
+    def __post_init__(self):
+        # Ensure the data field is the correct length.
+        data = bytearray(self.body)
+        if len(data) > DATA_SIZE:
+            self.body = bytes(data[:DATA_SIZE])  # Truncate to the specified length
+        elif len(data) < DATA_SIZE:
+            self.body = bytes(data + bytearray(DATA_SIZE - len(data)))  # Extend with zeroes
+
     @classmethod
     def deserialize(cls, msg_bytes: bytes) -> "Message":
         """Create a message from serialized bytes."""
@@ -30,19 +38,12 @@ class Message:
 
     def serialize(self) -> bytes:
         """Return the serialized bytes of the message."""
-        # Ensure the data field is the correct length.
-        data = bytearray(self.body)
-        if len(data) > DATA_SIZE:
-            return data[:DATA_SIZE]  # Truncate to the specified length
-        elif len(data) < DATA_SIZE:
-            return data + bytearray(DATA_SIZE - len(data))  # Extend with zeroes
-
         return bytes(bytearray([
             self.priority,
             self.sender.value,
             self.recipient.value,
             self.cmd_id.value])
-            + data
+            + self.body
         )
 
 

--- a/soti/parser.py
+++ b/soti/parser.py
@@ -80,7 +80,10 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
     """
     parts = args.split()
 
-    cmd_id = CmdID(parse_int(parts[0]))
+    try:
+        cmd_id = CmdID(parse_int(parts[0]))
+    except ValueError:
+        raise ArgumentException(f"Invalid command ID {parts[0]}")
 
     # Assign default values for the command options.
     priority: int = COMM_INFO[cmd_id]["priority"]

--- a/soti/parser.py
+++ b/soti/parser.py
@@ -1,0 +1,139 @@
+"""
+The SOTI parser.
+"""
+
+from utils.constants import (
+    NodeID, CmdID, DATA_SIZE
+)
+
+class ArgumentException(Exception):
+    pass
+
+
+def parse_send(args: str) -> tuple[bytes, str, dict, str]:
+    """Parses arguments for `do_send`."""
+    parts = args.split()
+
+    cmd_id = parts[0]
+    data = bytearray(DATA_SIZE)
+    data_index = 0
+    options = {}
+
+    for part in parts[1:]:
+        arg = part
+        try:
+            # check if key-value pair
+            if '=' in arg:  
+                key, value = arg.split('=')
+                options[key] = value
+
+            # treat as data argument
+            elif data_index < DATA_SIZE:
+                # check if integer type was provided
+                explicit_type = arg[0] == "("
+
+                if explicit_type:
+                    type_end = arg.find(")")
+                    if type_end <= 0: 
+                        raise ValueError()
+
+                    type = arg[1 : type_end]
+
+                    # only signed if first character is "i"
+                    explicit_sign = not type[0].isnumeric()
+                    signed = type[0] == "i" if explicit_sign else False
+
+                    # slice from 1 if sign was provided
+                    target_size = int(type[int(explicit_sign):]) // 8
+
+                    # remove the cast from the argument
+                    arg = arg[type_end + 1 :]
+
+                negative = arg[0] == "-"
+                if negative: 
+                    # remove negative sign
+                    arg = arg[1:]
+
+                if not explicit_type:
+                    # defaults to unsigned unless negative
+                    signed = negative
+
+                    # determine minimum byte size to store the number
+                    if arg[:2] == "0b":
+                        size = (len(arg) - 2 + 7) // 8
+                    elif arg[:2] == "0x":
+                        size = (len(arg) - 2 + 1) // 2
+                    else: # decimal
+                        size = (len(format(parse_int(arg), 'x')) + 1) // 2
+
+                    # determine nearest integer width (1, 2, 4 bytes)
+                    target_size = 1
+                    while target_size < size: target_size *= 2
+
+                # value is the absolute value of the number
+                value = parse_int(arg)
+
+                max_unsigned = 2 ** (target_size * 8) - 1
+                max_signed = max_unsigned // 2
+
+                # handle overflows based on signedness
+                if value > max_unsigned:
+                    raise ArgumentException(f"Overflow from {part}")
+                elif not signed and negative:
+                    raise ArgumentException(f"{part} cannot be unsigned and negative")
+                
+                elif signed and value > max_signed:
+                    if not negative:
+                        # overflow to negative two's complement
+                        value = value - max_unsigned - 1
+                    elif value > max_signed + 1:
+                        # negative underflow
+                        raise ArgumentException(f"Underflow from {part}")
+
+                if negative:
+                    value *= -1
+
+                # create a bytes object
+                value = int(value).to_bytes(target_size, byteorder="little", signed=signed)
+                # insert the value into data
+                end_index = data_index + target_size
+                data[data_index : end_index] = value
+                data_index = end_index
+
+        except ValueError:
+            raise ArgumentException(f"Invalid argument '{part}'")
+        except IndexError:
+            raise ArgumentException(f"Invalid syntax: {part}")
+        except ArgumentException as e:
+            raise ArgumentException(e) from e
+
+    # truncate extra bytes
+    data = data[:DATA_SIZE]
+
+    return cmd_id, bytes(data), options
+
+
+def parse_int(i) -> int:
+    """
+    Casts numbers and enum members to int.
+    Raises ValueError for invalid values.
+    """
+    try:
+        if isinstance(i, int):
+            return i
+        elif isinstance(i, str):
+            if i.isnumeric():
+                return int(i)
+            if i[:2] == "0x":
+                return int(i, 16)
+            if i[:2] == "0b":
+                return int(i, 2)
+            if i in NodeID.__members__:
+                return NodeID[i].value
+            if i in CmdID.__members__:
+                return CmdID[i].value
+        # no valid cast
+        raise ValueError()
+    except (ValueError) as e:
+        # raises an exception for the caller
+        raise ValueError(e) from e

--- a/soti/parser.py
+++ b/soti/parser.py
@@ -2,138 +2,158 @@
 The SOTI parser.
 """
 
+import re
+from message import Message
 from utils.constants import (
-    NodeID, CmdID, DATA_SIZE
+    NodeID, CmdID, COMM_INFO, DATA_SIZE
 )
+
+DATA_ARG_RE = re.compile(r'(?:\((\w+)\))?(\S+)')
+
 
 class ArgumentException(Exception):
     pass
 
 
-def parse_send(args: str) -> tuple[bytes, str, dict]:
-    """Parses arguments for `do_send`."""
-    parts = args.split()
-
-    cmd_id = parts[0]
-    data = bytearray(DATA_SIZE)
-    data_index = 0
-    options = {}
-
-    for part in parts[1:]:
-        arg = part
-        try:
-            # check if key-value pair
-            if '=' in arg:  
-                key, value = arg.split('=')
-                options[key] = value
-
-            # treat as data argument
-            elif data_index < DATA_SIZE:
-                # check if integer type was provided
-                explicit_type = arg[0] == "("
-
-                if explicit_type:
-                    type_end = arg.find(")")
-                    if type_end <= 0: 
-                        raise ValueError()
-
-                    type = arg[1 : type_end]
-
-                    # only signed if first character is "i"
-                    explicit_sign = not type[0].isnumeric()
-                    signed = type[0] == "i" if explicit_sign else False
-
-                    # slice from 1 if sign was provided
-                    target_size = int(type[int(explicit_sign):]) // 8
-
-                    # remove the cast from the argument
-                    arg = arg[type_end + 1 :]
-
-                negative = arg[0] == "-"
-                if negative: 
-                    # remove negative sign
-                    arg = arg[1:]
-
-                if not explicit_type:
-                    # defaults to unsigned unless negative
-                    signed = negative
-
-                    # determine minimum byte size to store the number
-                    if arg[:2] == "0b":
-                        size = (len(arg) - 2 + 7) // 8
-                    elif arg[:2] == "0x":
-                        size = (len(arg) - 2 + 1) // 2
-                    else: # decimal
-                        size = (len(format(parse_int(arg), 'x')) + 1) // 2
-
-                    # determine nearest integer width (1, 2, 4 bytes)
-                    target_size = 1
-                    while target_size < size: target_size *= 2
-
-                # value is the absolute value of the number
-                value = parse_int(arg)
-
-                max_unsigned = 2 ** (target_size * 8) - 1
-                max_signed = max_unsigned // 2
-
-                # handle overflows based on signedness
-                if value > max_unsigned:
-                    raise ArgumentException(f"Overflow from {part}")
-                elif not signed and negative:
-                    raise ArgumentException(f"{part} cannot be unsigned and negative")
-                
-                elif signed and value > max_signed:
-                    if not negative:
-                        # overflow to negative two's complement
-                        value = value - max_unsigned - 1
-                    elif value > max_signed + 1:
-                        # negative underflow
-                        raise ArgumentException(f"Underflow from {part}")
-
-                if negative:
-                    value *= -1
-
-                # create a bytes object
-                value = int(value).to_bytes(target_size, byteorder="little", signed=signed)
-                # insert the value into data
-                end_index = data_index + target_size
-                data[data_index : end_index] = value
-                data_index = end_index
-
-        except ValueError:
-            raise ArgumentException(f"Invalid argument '{part}'")
-        except IndexError:
-            raise ArgumentException(f"Invalid syntax: {part}")
-        except ArgumentException as e:
-            raise ArgumentException(e) from e
-
-    # truncate extra bytes
-    data = data[:DATA_SIZE]
-
-    return cmd_id, bytes(data), options
-
-
-def parse_int(i) -> int:
+def parse_int(s: str) -> int:
     """
     Casts numbers and enum members to int.
     Raises ValueError for invalid values.
     """
-    try:
-        if isinstance(i, int):
-            return i
-        elif isinstance(i, str):
-            if i.isnumeric():
-                return int(i)
-            if i[:2] == "0x":
-                return int(i, 16)
-            if i[:2] == "0b":
-                return int(i, 2)
-            if i in NodeID.__members__:
-                return NodeID[i].value
-            if i in CmdID.__members__:
-                return CmdID[i].value
-        # no valid cast
+    is_negative = False
+    if s[0] == '-':
+        is_negative = True
+        s = s[1:]
+
+    i: int = 0
+    if s.isnumeric():
+        i = int(s)
+    elif s[:2] == "0x":
+        i = int(s, 16)
+    elif s[:2] == "0b":
+        i = int(s, 2)
+    elif s in NodeID.__members__:
+        i = NodeID[s].value
+    elif s in CmdID.__members__:
+        i = CmdID[s].value
+    else:
+        # no valid parsing
         raise ValueError()
-    except (ValueError) as e:
-        # raises an exception for the caller
-        raise ValueError(e) from e
+
+    if is_negative:
+        i = -i
+
+    return i
+
+
+def get_implied_type(value: int) -> str:
+    """Uses the range of the integer to infer an appropriate type to store the value."""
+    if value < 0:
+        if -(2**7) <= value < 2**7:
+            return "i8"
+        elif -(2**15) <= value < 2**15:
+            return "i16"
+        elif -(2**31) <= value < 2**31:
+            return "i32"
+        else:
+            raise ValueError(f"{value} is out of range for signed 32-bit integer.")
+    else:
+        if 0 <= value < 2**8:
+            return "u8"
+        elif 2**8 <= value < 2**16:
+            return "u16"
+        elif 2**16 <= value < 2**32:
+            return "u32"
+        else:
+            raise ValueError(f"{value} is out of range for unsigned 32-bit integer.")
+
+
+def parse_send(args: str, default_sender: NodeID) -> Message:
+    """Parses arguments for the 'send' command.
+
+    Syntax:
+    <Command ID> [Optional Data] [Key-Value Options]
+
+    Function Arguments:
+    args -- string containing the command arguments.
+    default_sender -- the sender ID if none is specified in the command.
+    """
+    parts = args.split()
+
+    cmd_id = CmdID(parse_int(parts[0]))
+
+    # Assign default values for the command options.
+    priority: int = COMM_INFO[cmd_id]["priority"]
+    sender_id: NodeID = default_sender
+    recipient_id: NodeID | None = COMM_INFO[cmd_id]["dest"]
+
+    # represents the bytes that will be sent in the data section of the message
+    data = bytearray()
+    data_index = 0
+
+    for arg in parts[1:]:
+        try:
+            # check if key-value pair
+            if '=' in arg:
+                key, value = arg.split('=')
+                if key == "priority":
+                    priority = parse_int(value)
+                    if not 0 <= priority <= 32:
+                        raise ArgumentException(f"Invalid priority '{key}'. Expected range is [0, 32]")
+                elif key == "from":
+                    try:
+                        sender_id = NodeID(parse_int(value))
+                    except ValueError as exc:
+                        raise ArgumentException(f"Invalid node ID '{value}'") from exc
+                elif key == "to":
+                    try:
+                        recipient_id = NodeID(parse_int(value))
+                    except ValueError as exc:
+                        raise ArgumentException(f"Invalid node ID '{value}'") from exc
+                else:
+                    raise ArgumentException(f"Unknown option '{key}'")
+
+            # treat as data argument
+            elif data_index < DATA_SIZE:
+                data_type = None
+                data_size = 0
+                is_signed = False
+
+                re_match = DATA_ARG_RE.match(arg)
+                if not re_match:
+                    raise ArgumentException(f"Invalid syntax for data argument '{arg}'")
+
+                data_type = re_match.group(1)
+                value = parse_int(re_match.group(2))
+
+                if not data_type:
+                    data_type = get_implied_type(value)
+
+                if data_type in ["u8", "u16", "u32"]:
+                    is_signed = False
+                elif data_type in ["i8", "i16", "i32"]:
+                    is_signed = True
+
+                if data_type in ["u8", "i8"]:
+                    data_size = 1
+                elif data_type in ["u16", "i16"]:
+                    data_size = 2
+                elif data_type in ["u32", "i32"]:
+                    data_size = 3
+
+                # create a bytes object
+                data.extend(value.to_bytes(data_size, byteorder="little", signed=is_signed))
+
+        except ValueError as exc:
+            raise ArgumentException(f"Invalid argument '{arg}': {exc}") from exc
+
+    if recipient_id is None:
+        raise ArgumentException(f"You must specify a recipient with the 'to' option for {cmd_id.name}")
+
+    # Ensure the data field is the correct length.
+    if len(data) > DATA_SIZE:
+        data = data[:DATA_SIZE]  # Truncate to the right length.
+    elif len(data) < DATA_SIZE:
+        data = data + bytearray(DATA_SIZE - len(data))  # Extend with zeroes.
+
+    return Message(priority, sender_id, recipient_id, cmd_id, bytes(data), source="user")

--- a/soti/parser.py
+++ b/soti/parser.py
@@ -37,8 +37,7 @@ def parse_int(s: str) -> int:
     elif s in CmdID.__members__:
         i = CmdID[s].value
     else:
-        # no valid parsing
-        raise ValueError()
+        raise ValueError(f"'{s}' cannot be parsed as an int")
 
     if is_negative:
         i = -i
@@ -83,7 +82,7 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
     try:
         cmd_id = CmdID(parse_int(parts[0]))
     except ValueError:
-        raise ArgumentException(f"Invalid command ID {parts[0]}")
+        raise ArgumentException(f"Invalid command ID '{parts[0]}'")
 
     # Assign default values for the command options.
     priority: int = COMM_INFO[cmd_id]["priority"]
@@ -143,6 +142,8 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
                     data_size = 2
                 elif data_type in ["u32", "i32"]:
                     data_size = 4
+                else:
+                    raise ArgumentException(f"Invalid type '{data_type}'")
 
                 # create a bytes object
                 data.extend(value.to_bytes(data_size, byteorder="little", signed=is_signed))

--- a/soti/parser.py
+++ b/soti/parser.py
@@ -154,10 +154,4 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
     if recipient_id is None:
         raise ArgumentException(f"You must specify a recipient with the 'to' option for {cmd_id.name}")
 
-    # Ensure the data field is the correct length.
-    if len(data) > DATA_SIZE:
-        data = data[:DATA_SIZE]  # Truncate to the right length.
-    elif len(data) < DATA_SIZE:
-        data = data + bytearray(DATA_SIZE - len(data))  # Extend with zeroes.
-
     return Message(priority, sender_id, recipient_id, cmd_id, bytes(data), source="user")

--- a/soti/parser.py
+++ b/soti/parser.py
@@ -139,7 +139,7 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
                 elif data_type in ["u16", "i16"]:
                     data_size = 2
                 elif data_type in ["u32", "i32"]:
-                    data_size = 3
+                    data_size = 4
 
                 # create a bytes object
                 data.extend(value.to_bytes(data_size, byteorder="little", signed=is_signed))

--- a/soti/parser.py
+++ b/soti/parser.py
@@ -10,7 +10,7 @@ class ArgumentException(Exception):
     pass
 
 
-def parse_send(args: str) -> tuple[bytes, str, dict, str]:
+def parse_send(args: str) -> tuple[bytes, str, dict]:
     """Parses arguments for `do_send`."""
     parts = args.split()
 

--- a/soti/parser.py
+++ b/soti/parser.py
@@ -145,8 +145,14 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
                 else:
                     raise ArgumentException(f"Invalid type '{data_type}'")
 
-                # create a bytes object
-                data.extend(value.to_bytes(data_size, byteorder="little", signed=is_signed))
+                # Convert value to a bytes object.
+                try:
+                    raw_bytes = value.to_bytes(data_size, byteorder="little", signed=is_signed)
+                except OverflowError as exc:
+                    raise ArgumentException(f"Integer overflow. '{re_match.group(2)}' cannot be represented as {data_type}") from exc
+
+                # Add the bytes of data.
+                data.extend(raw_bytes)
 
         except ValueError as exc:
             raise ArgumentException(f"Invalid argument '{arg}': {exc}") from exc

--- a/soti/utils/constants.py
+++ b/soti/utils/constants.py
@@ -14,6 +14,8 @@ SESSION_FILE_FORMAT = "%Y-%m-%d_%H%M%S"
 
 # The length of a serialized message in bytes.
 MSG_SIZE = 11
+# The length of a message's data payload in bytes.
+DATA_SIZE = 7
 
 
 class NodeID(Enum):


### PR DESCRIPTION
Solves #30, #32

Creates `parser.py`, which provides `parse_int()` to resolve various command arguments into an integer, and an updated `parse_send()` which allows the user to specify the integer types of their data arguments.

An example of a `send` command using some new features:
`>> send CDH_PROCESS_TELEMETRY_REPORT from=PLD priority=0x20 (u8)0b11 0x0802 66000`

Sends the message:
```
- time: 14:04:41
  source: user
  priority: 32
  sender-id: PLD
  recipient-id: CDH
  cmd: CDH_PROCESS_TELEMETRY_REPORT
  body: 
    telemetry-key: 3
    sequence-number: 2
    packet-number: 8
    telemetry: 0xd0010100
```