### PR TITLE
add ack option to parse_send function

### DIFF
--- a/soti/message.py
+++ b/soti/message.py
@@ -12,6 +12,7 @@ class Message:
     cmd_id: CmdID
     body: bytes = field(default_factory=([0] * 7))
     # additional parameters
+    is_ack: bool = field(default=False)
     source: str = field(default="unspecified")
     time: datetime = field(default_factory=
         lambda: datetime.now().strftime("%T")
@@ -56,5 +57,6 @@ class Message:
             "sender-id": self.sender,
             "recipient-id": self.recipient,
             "cmd": self.cmd_id,
-            "body": parse_msg_body(self.cmd_id, self.body)
+            "body": parse_msg_body(self.cmd_id, self.body),
+            "ack": self.is_ack,
         }

--- a/soti/parser.py
+++ b/soti/parser.py
@@ -88,6 +88,8 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
     priority: int = COMM_INFO[cmd_id]["priority"]
     sender_id: NodeID = default_sender
     recipient_id: NodeID | None = COMM_INFO[cmd_id]["dest"]
+    is_ack: bool = False
+
 
     # represents the bytes that will be sent in the data section of the message
     data = bytearray()
@@ -112,6 +114,13 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
                         recipient_id = NodeID(parse_int(value))
                     except ValueError as exc:
                         raise ArgumentException(f"Invalid node ID '{value}'") from exc
+                elif key == "ack":
+                    if value.lower() == "true":
+                        is_ack = True
+                    elif value.lower() == "false":
+                        is_ack = False
+                    else:
+                        raise ArgumentException(f"Invalid value for ack '{value}'. Expected true or false")
                 else:
                     raise ArgumentException(f"Unknown option '{key}'")
 
@@ -160,4 +169,4 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
     if recipient_id is None:
         raise ArgumentException(f"You must specify a recipient with the 'to' option for {cmd_id.name}")
 
-    return Message(priority, sender_id, recipient_id, cmd_id, bytes(data), source="user")
+    return Message(priority, sender_id, recipient_id, cmd_id, bytes(data), is_ack=is_ack, source="user")


### PR DESCRIPTION
This PR adds support for manually sending ACK messages from the SOTI CLI.

- Adds an `ack=true/false` option to the `send` command
- Stores the ACK flag in the Message object (default false)
- Maintains compatibility with existing commands

This allows testing of satellite behavior under unexpected ACK scenarios.


<img width="688" height="780" alt="Screenshot 2025-12-21 000006" src="https://github.com/user-attachments/assets/a4335ce4-c891-43b3-a83d-da84e7c83557" />
