### PR TITLE
Add ack option to send command in SOTI CLI

### DIFF
--- a/soti/umsats_soti/parser/parser.py
+++ b/soti/umsats_soti/parser/parser.py
@@ -104,6 +104,7 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
     priority: int = 255
     sender_id: NodeID = default_sender
     recipient_id: NodeID | None = get_implied_recipient(cmd_id)
+    is_ack: bool = False
 
     # represents the bytes that will be sent in the data section of the message
     data = bytearray()
@@ -128,6 +129,13 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
                         recipient_id = NodeID(parse_int(value))
                     except ValueError as exc:
                         raise ArgumentException(f"Invalid node ID '{value}'") from exc
+                elif key == "ack":
+                    if value.lower() == "true":
+                        is_ack = True
+                    elif value.lower() == "false":
+                        is_ack = False
+                    else:
+                        raise ArgumentException(f"Invalid value for ack '{value}'. Expected true or false")
                 else:
                     raise ArgumentException(f"Unknown option '{key}'")
 
@@ -183,5 +191,5 @@ def parse_send(args: str, default_sender: NodeID) -> Message:
         priority,
         sender_id,
         recipient_id,
-        False
+        is_ack
     )


### PR DESCRIPTION
- Added `ack` key-value option to `parse_send`
- Defaults to `false` if not specified
- Does not affect existing message behavior

<img width="1004" height="907" alt="Screenshot 2025-12-23 181845" src="https://github.com/user-attachments/assets/aea82034-4e97-41d1-ba9b-bea25e6d4c02" />
