### PR TITLE
fix: proper quitting

### DIFF
--- a/soti/umsats_soti/__main__.py
+++ b/soti/umsats_soti/__main__.py
@@ -28,6 +28,8 @@ class App():
     def run(self):
         try:
             self.loop.run()
+        except KeyboardInterrupt:
+            pass
         finally:
             self.current_screen.on_exit(self.loop)
 

--- a/soti/umsats_soti/device.py
+++ b/soti/umsats_soti/device.py
@@ -56,23 +56,28 @@ class SerialDevice(Device):
             print(f"[SerialDevice: {self.port}] Failed to open serial port: {e}")
             return
 
-        while True:
-            try:
-                msg = self._write_queue.get_nowait()
-                if msg is None: # Check for termination sentinel
-                    break  # Exit process
-                ser.write(msg.serialize())
-            except queue.Empty:
-                pass
-
-            # Read if bytes are available
-            if ser.in_waiting >= MSG_SIZE:
-                data = ser.read(MSG_SIZE)
+        try:
+            while True:
                 try:
-                    msg = Message.deserialize(data)
-                    self._read_queue.put(msg)
-                except Exception as e:
-                    print(f"[SerialDevice: {self.port}] Deserialization error: {e}")
+                    msg = self._write_queue.get_nowait()
+                    if msg is None: # Check for termination sentinel
+                        break  # Exit process
+                    ser.write(msg.serialize())
+                except queue.Empty:
+                    pass
+
+                # Read if bytes are available
+                if ser.in_waiting >= MSG_SIZE:
+                    data = ser.read(MSG_SIZE)
+                    try:
+                        msg = Message.deserialize(data)
+                        self._read_queue.put(msg)
+                    except KeyboardInterrupt:
+                        raise
+                    except Exception as e:
+                        print(f"[SerialDevice: {self.port}] Deserialization error: {e}")
+        except KeyboardInterrupt:
+            pass
 
         ser.close()
 
@@ -81,11 +86,14 @@ class VirtualDevice(Device):
     """For when no device is selected."""
     def _run(self):
         # Echo messages back to the user.
-        while True:
-            try:
-                msg = self._write_queue.get_nowait()
-                if msg is None: # Check for termination sentinel
-                    break  # Exit process
-                self._read_queue.put(msg)
-            except queue.Empty:
-                pass
+        try:
+            while True:
+                try:
+                    msg = self._write_queue.get_nowait()
+                    if msg is None: # Check for termination sentinel
+                        break  # Exit process
+                    self._read_queue.put(msg)
+                except queue.Empty:
+                    pass
+        except KeyboardInterrupt:
+            pass


### PR DESCRIPTION
Ensure the program exits without stack traces when using q or Ctrl+C

Note: Quitting can take up to 6 seconds since Urwid needs to free resources. Sometimes when hitting Ctrl+C, you may need to hit another key (such as an up or down arrow) to trigger the exit call (Not sure why this is).

Closes #52.